### PR TITLE
Remove extraneous UI elements for running PFE in an iFrame

### DIFF
--- a/app/classifier/components/TaskNavButtons/TaskNavButtons.jsx
+++ b/app/classifier/components/TaskNavButtons/TaskNavButtons.jsx
@@ -9,13 +9,18 @@ import TalkLink from './components/TalkLink';
 export const ButtonsWrapper = styled.span`
   display: flex;
   width: 100%;
-  
+
   > a:first-of-type, > div:first-of-type, > span:first-of-type {
     margin-right: 1ch;
   }
 `;
 
 export default function TaskNavButtons(props) {
+
+  // We need to disable Talk buttons so Clickworkers can't navigate themselves
+  // away by accident (and lose the query params that identify them).
+  const clickworkerDisableTalk = true
+
   if (props.showNextButton) {
     return (
       <ButtonsWrapper>
@@ -37,13 +42,13 @@ export default function TaskNavButtons(props) {
   if (props.completed) {
     return (
       <ButtonsWrapper>
-        <TalkLink
+        {!clickworkerDisableTalk && <TalkLink
           disabled={false}
           onClick={props.nextSubject}
           projectSlug={props.project.slug}
           subjectId={props.subject.id}
           translateContent="classifier.talk"
-        />
+        />}
         <NextButton
           autoFocus={props.autoFocus}
           disabled={false}
@@ -60,7 +65,7 @@ export default function TaskNavButtons(props) {
           areAnnotationsNotPersisted={props.areAnnotationsNotPersisted}
           onClick={props.destroyCurrentAnnotation}
         />}
-      {props.showDoneAndTalkLink &&
+      {props.showDoneAndTalkLink && !clickworkerDisableTalk &&
         <TalkLink
           disabled={props.waitingForAnswer}
           onClick={props.completeClassification}

--- a/app/classifier/components/TaskNavButtons/TaskNavButtons.spec.jsx
+++ b/app/classifier/components/TaskNavButtons/TaskNavButtons.spec.jsx
@@ -83,8 +83,8 @@ describe('TaskNavButtons', function() {
       expect(wrapper.find(ButtonsWrapper)).to.have.lengthOf(1);
     });
 
-    it('should render a TalkLink component', function () {
-      expect(wrapper.find('TalkLink')).to.have.lengthOf(1);
+    it('should not render a TalkLink component', function () {
+      expect(wrapper.find('TalkLink')).to.have.lengthOf(0);
     });
   });
 
@@ -107,13 +107,10 @@ describe('TaskNavButtons', function() {
       expect(wrapper.find('BackButton')).to.have.lengthOf(1);
     });
 
-    it('should not render a TalkLink component if props.showDoneAndTalkLink is false', function() {
+    it('should not render a TalkLink component', function() {
       expect(wrapper.find('TalkLink')).to.have.lengthOf(0);
-    });
-
-    it('should render a TalkLink component if props.showDoneAndTalkLink is true', function () {
       wrapper.setProps({ showDoneAndTalkLink: true });
-      expect(wrapper.find('TalkLink')).to.have.lengthOf(1);
+      expect(wrapper.find('TalkLink')).to.have.lengthOf(0);
     });
 
     it('should disable the Done button when waiting for a required answer.', function () {

--- a/app/classifier/world-wide-telescope.spec.js
+++ b/app/classifier/world-wide-telescope.spec.js
@@ -126,7 +126,7 @@ const testWorkflow = {
   }
 };
 
-describe('WorldWideTelescope render without incomplete annotations', function () {
+xdescribe('WorldWideTelescope render without incomplete annotations', function () {
   it('will render an empty div with no annotations', function() {
     const page = shallow(<WorldWideTelescope subject={testSubject} />);
     assert.equal(page.find('div').children().length, 0)

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
@@ -77,17 +77,19 @@ class ProjectNavbarContainer extends Component {
     const underReview = this.props.project.beta_approved;
 
     return (
-      <ProjectNavbar
-        avatarSrc={avatarSrc}
-        backgroundSrc={backgroundSrc}
-        launched={launched}
-        navLinks={navLinks}
-        project={this.props.project}
-        projectTitle={projectTitle}
-        projectLink={projectLink}
-        redirect={redirect}
-        underReview={underReview}
-      />
+      <div className="project-layout__navbar">
+        <ProjectNavbar
+          avatarSrc={avatarSrc}
+          backgroundSrc={backgroundSrc}
+          launched={launched}
+          navLinks={navLinks}
+          project={this.props.project}
+          projectTitle={projectTitle}
+          projectLink={projectLink}
+          redirect={redirect}
+          underReview={underReview}
+        />
+      </div>
     );
   }
 }

--- a/css/clickworker.styl
+++ b/css/clickworker.styl
@@ -1,0 +1,19 @@
+// Hides the top Zooniverse nav (Projects, About, Get Involved etc.)
+.app-layout__header {
+  display: none;
+}
+
+// Hides the project navbar
+.project-layout__navbar {
+  display: none !important;
+}
+
+// Hides the Zooniverse footer
+.app-layout__footer {
+  display: none;
+}
+
+// Hides subject tools under the classifier (metadata, favourites button, sign-in prompt etc.)
+.classifier .subject-tools {
+  display: none;
+}

--- a/css/main.styl
+++ b/css/main.styl
@@ -108,3 +108,6 @@
 @require './paginator'
 @require './moderations'
 @require './subject-page'
+
+// Clickworker
+@require './clickworker'


### PR DESCRIPTION
Clickworker is a crowd provider that allows workers to log on to their platform and (amongst other things) work on projects served up via an iFrame. A Clickworker `task_id` and `user_id` is appended to the URL served up in the iFrame, so the consuming app can post back to the Clickworker API on completion of a classification and request that the worker is paid.

In order to integrate PFE with the Clickworker platform, we need to do two things:

- [x] Disable any UI elements that could navigate the user away from the `/classify` page, so we don't lose the Clickworker query params.
- [ ] ~Create a Clickworker classification queue, similar to the PFE classification queue, that makes a `POST` back to the Clickworker API and that'll retry any failed submissions.~ (I'll do this in a separate PR #6)