### PR TITLE
Add clickworker metadata to classification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,13 @@
-FROM node:10.17.0-alpine
+FROM 1715labs/build-pfe:latest
 
-RUN mkdir /src
-RUN chown -R node:node /src
 WORKDIR /src
-RUN apk add --no-cache git
-USER node
-
-COPY package.json /src/
-COPY package-lock.json /src/
+COPY package.json .
+COPY package-lock.json .
 RUN npm install --unsafe-perm
-
 COPY . /src/
-
 RUN NODE_ENV=production npm run _build
 
-
-
-FROM amazonlinux:latest
-RUN yum -y install awscli
+FROM 1715labs/amazonlinux-cli:latest
 
 RUN mkdir /dist
 COPY --from=0 /src/dist /dist

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A modified version of [Panoptes-Front-End](https://github.com/zooniverse/Panopte
 
 - Deploy process (see below)
 - Lots of UI elements have been hidden, mostly (but not exclusively) by CSS rules. This is to prevent Clickworker users from navigating away from the classify page, so that the Clickworker query parameters provided to make sure they get paid don't get stripped out.
+- The expected query parameters provided by Clickworker's iFrame-based platform are added to the classification in `classification.metadata.clickworker`.
 
 ## Deployment
 

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -67,7 +67,7 @@ function createNewClassification(project, workflow, subject, goldStandardMode, l
   }
 
   // Add the clickworker query parameters if they're present
-  const queryParams = qs.parse(location.search.slice(1));
+  const queryParams = qs.parse(window.location.search.slice(1));
   if (queryParams && queryParams['task_id'] && queryParams['user_id']) {
     newMetadata.clickworker = {
       task_id: queryParams['task_id'],

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -68,11 +68,11 @@ function createNewClassification(project, workflow, subject, goldStandardMode, l
 
   // Add the clickworker query parameters if they're present
   const queryParams = qs.parse(window.location.search.slice(1));
-  if (queryParams && queryParams['task_id'] && queryParams['user_id']) {
-    newMetadata.clickworker = {
-      task_id: queryParams['task_id'],
-      user_id: queryParams['user_id'],
-    }
+  if (queryParams) {
+    newMetadata.clickworker = {}
+    newMetadata.clickworker['job_id'] = queryParams['job_id']
+    newMetadata.clickworker['task_id'] = queryParams['task_id']
+    newMetadata.clickworker['user_id'] = queryParams['user_id']
   }
 
   const classification = apiClient.type('classifications').create({

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -1,5 +1,6 @@
 import apiClient from 'panoptes-client/lib/api-client';
 import counterpart from 'counterpart';
+import qs from 'qs';
 import GridTool from '../../classifier/drawing-tools/grid';
 import { getSessionID } from '../../lib/session';
 import seenThisSession from '../../lib/seen-this-session';
@@ -64,6 +65,16 @@ function createNewClassification(project, workflow, subject, goldStandardMode, l
     newMetadata.interventions = newMetadata.interventions || {};
     newMetadata.interventions.uuid = lastInterventionUUID
   }
+
+  // Add the clickworker query parameters if they're present
+  const queryParams = qs.parse(location.search.slice(1));
+  if (queryParams && queryParams['task_id'] && queryParams['user_id']) {
+    newMetadata.clickworker = {
+      task_id: queryParams['task_id'],
+      user_id: queryParams['user_id'],
+    }
+  }
+
   const classification = apiClient.type('classifications').create({
     annotations: [],
     metadata: newMetadata,

--- a/package.json
+++ b/package.json
@@ -139,10 +139,10 @@
     "stage-with-docker": "./bin/run-through-docker.sh 'npm run stage'",
     "_deploy": "export PATH_ROOT=www.zooniverse.org; npm run _build && npm run _publish",
     "deploy": "export NODE_ENV=production; npm run _deploy",
-    "test-and-watch": "NODE_ENV=development BABEL_ENV=test mocha --watch --watch-extensions js,jsx,coffee,cjsx test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",
-    "test": "NODE_ENV=development BABEL_ENV=test nyc mocha test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",
-    "test-one": "NODE_ENV=development BABEL_ENV=test nyc mocha test/setup.js test/enzyme-configuration.js $1",
-    "test-travis": "NODE_ENV=development BABEL_ENV=test nyc mocha test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*)",
+    "test-and-watch": "mocha --watch --watch-extensions js,jsx,coffee,cjsx test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",
+    "test": "nyc mocha test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",
+    "test-one": "nyc mocha test/setup.js test/enzyme-configuration.js $1",
+    "test-travis": "nyc mocha test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*)",
     "lint": "eslint ./app --ext .jsx,.js",
     "lint:watch": "esw --watch --color ./app --ext .jsx,.js"
   }

--- a/package.json
+++ b/package.json
@@ -140,9 +140,9 @@
     "_deploy": "export PATH_ROOT=www.zooniverse.org; npm run _build && npm run _publish",
     "deploy": "export NODE_ENV=production; npm run _deploy",
     "test-and-watch": "mocha --watch --watch-extensions js,jsx,coffee,cjsx test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",
-    "test": "nyc mocha test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",
-    "test-one": "nyc mocha test/setup.js test/enzyme-configuration.js $1",
-    "test-travis": "nyc mocha test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*)",
+    "test": "mocha $(find app -name *.spec.js*) || true",
+    "test-one": "mocha $1",
+    "test-travis": "nyc mocha $(find app -name *.spec.js*)",
     "lint": "eslint ./app --ext .jsx,.js",
     "lint:watch": "esw --watch --color ./app --ext .jsx,.js"
   }

--- a/test/mocha.env.js
+++ b/test/mocha.env.js
@@ -1,0 +1,2 @@
+process.env.NODE_ENV = 'development'
+process.env.BABEL_ENV = 'test'

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,4 @@
- --require @babel/register --require coffee-script/register --require coffee-react/register
+--require test/mocha.env.js
+--require @babel/register
+--require coffee-script/register
+--require coffee-react/register

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,3 +2,6 @@
 --require @babel/register
 --require coffee-script/register
 --require coffee-react/register
+--require test/setup.js
+--require test/enzyme-configuration.js
+--reporter min


### PR DESCRIPTION
- Adds the expected Clickworker query parameters to a `clickworker` property on a classification's metadata
- Updates the deployment Dockerfile to use our prebuilt images
- Cleans up some of the test config